### PR TITLE
fix: HTML marker default pixelOffset value

### DIFF
--- a/docs-ref-autogen/azure-maps-control/atlas.HtmlMarkerOptions.yml
+++ b/docs-ref-autogen/azure-maps-control/atlas.HtmlMarkerOptions.yml
@@ -89,7 +89,7 @@ properties:
     summary: |-
       An offset in pixels to move the popup relative to the markers center.
       Negatives indicate left and up.
-      default `[0, -18]`
+      default `[0, 0]`
     fullName: pixelOffset
     remarks: ''
     isPreview: false


### PR DESCRIPTION
It was [0,-18].
but the correct value is [0, 0]