### PR TITLE
[Broken links] I deleted one of the broken FWlinks

### DIFF
--- a/docs-ref-autogen/azure-maps-rest/atlas.service.MobilityURL.yml
+++ b/docs-ref-autogen/azure-maps-rest/atlas.service.MobilityURL.yml
@@ -61,7 +61,7 @@ methods:
       operator details. The
 
       service supplements [Nearby Transit
-      API](https://aka.ms/AzureMapsMobilityNearbyTransit).
+      API](https://docs.microsoft.com/azure/azure-maps).
 
       Uses the Get Car Share Info API:
       https://docs.microsoft.com/rest/api/maps/mobility/getcarshareinfopreview


### PR DESCRIPTION
All of the FWlinks are broken. Suggestion is to link to the [Azure Maps landing page](https://docs.microsoft.com/azure/azure-maps).