### PR TITLE
Documentation update: MapControl 2.2.7, Indoor: 0.2.1

### DIFF
--- a/docs-ref-autogen/azure-maps-control/atlas.AuthenticationManager.yml
+++ b/docs-ref-autogen/azure-maps-control/atlas.AuthenticationManager.yml
@@ -11,6 +11,14 @@ remarks: ''
 isDeprecated: false
 type: interface
 methods:
+  - name: dispose()
+    uid: azure-maps-control.atlas.AuthenticationManager.dispose
+    package: azure-maps-control
+    summary: Cleans up any resources used by the authentication manager.
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: function dispose()
   - name: getAuthType()
     uid: azure-maps-control.atlas.AuthenticationManager.getAuthType
     package: azure-maps-control

--- a/docs-ref-autogen/azure-maps-control/atlas.Map.yml
+++ b/docs-ref-autogen/azure-maps-control/atlas.Map.yml
@@ -83,6 +83,18 @@ properties:
       return:
         description: ''
         type: <xref uid="azure-maps-control.atlas.ImageSpriteManager" />
+  - name: isDisposed
+    uid: azure-maps-control.atlas.Map.isDisposed
+    package: azure-maps-control
+    summary: Returns true if the map has been disposed.
+    fullName: isDisposed
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: boolean isDisposed
+      return:
+        description: ''
+        type: boolean
   - name: layers
     uid: azure-maps-control.atlas.Map.layers
     package: azure-maps-control

--- a/docs-ref-autogen/azure-maps-control/atlas.ServiceOptions.yml
+++ b/docs-ref-autogen/azure-maps-control/atlas.ServiceOptions.yml
@@ -178,6 +178,32 @@ properties:
       return:
         description: ''
         type: string
+  - name: styleAPIVersion
+    uid: azure-maps-control.atlas.ServiceOptions.styleAPIVersion
+    package: azure-maps-control
+    summary: The style API version used when requesting styles and stylesets
+    fullName: styleAPIVersion
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: 'styleAPIVersion?: string'
+      return:
+        description: ''
+        type: string
+  - name: styleDefinitionsVersion
+    uid: azure-maps-control.atlas.ServiceOptions.styleDefinitionsVersion
+    package: azure-maps-control
+    summary: |-
+      The style definitions version to request when requesting styles
+      from styleDefinitionsPath.
+    fullName: styleDefinitionsVersion
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: 'styleDefinitionsVersion?: string'
+      return:
+        description: ''
+        type: string
   - name: subscriptionKey
     uid: azure-maps-control.atlas.ServiceOptions.subscriptionKey
     package: azure-maps-control

--- a/docs-ref-autogen/azure-maps-indoor/atlas.control.LevelControlOptions.yml
+++ b/docs-ref-autogen/azure-maps-indoor/atlas.control.LevelControlOptions.yml
@@ -8,6 +8,20 @@ remarks: ''
 isDeprecated: false
 type: class
 properties:
+  - name: levelLabel
+    uid: azure-maps-indoor.atlas.control.LevelControlOptions.levelLabel
+    package: azure-maps-indoor
+    summary: |-
+      Level label type
+      Default `ordinal`
+    fullName: levelLabel
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: 'levelLabel?: "ordinal" | "name"'
+      return:
+        description: ''
+        type: '"ordinal" | "name"'
   - name: position
     uid: azure-maps-indoor.atlas.control.LevelControlOptions.position
     package: azure-maps-indoor

--- a/docs-ref-autogen/azure-maps-indoor/atlas.indoor.IMap.yml
+++ b/docs-ref-autogen/azure-maps-indoor/atlas.indoor.IMap.yml
@@ -8,6 +8,18 @@ remarks: ''
 isDeprecated: false
 type: interface
 properties:
+  - name: isDisposed
+    uid: azure-maps-indoor.atlas.indoor.IMap.isDisposed
+    package: azure-maps-indoor
+    summary: Returns true if the map has been disposed.
+    fullName: isDisposed
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: boolean isDisposed
+      return:
+        description: ''
+        type: boolean
   - name: layers
     uid: azure-maps-indoor.atlas.indoor.IMap.layers
     package: azure-maps-indoor

--- a/docs-ref-autogen/azure-maps-indoor/atlas.indoor.IndoorManager.yml
+++ b/docs-ref-autogen/azure-maps-indoor/atlas.indoor.IndoorManager.yml
@@ -154,6 +154,28 @@ methods:
     isDeprecated: false
     syntax:
       content: function dispose()
+  - name: 'focusCamera(azmaps.CameraBoundsOptions & azmaps.AnimationOptions, string)'
+    uid: azure-maps-indoor.atlas.indoor.IndoorManager.focusCamera
+    package: azure-maps-indoor
+    summary: Focuses the camera on indoor facilities.
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: >-
+        function focusCamera(options?: azmaps.CameraBoundsOptions &
+        azmaps.AnimationOptions, tilesetId?: string)
+      parameters:
+        - id: options
+          type: >-
+            <xref uid="azmaps.CameraBoundsOptions" /> & <xref
+            uid="azmaps.AnimationOptions" />
+          description: camera bounds options.
+        - id: tilesetId
+          type: string
+          description: >
+            when indoor map configuration is used, tilesetId can be provided to
+            focus on a specific facility only, otherwise bounds that enclose all
+            facilities will be used.
   - name: setDynamicStyling(boolean)
     uid: azure-maps-indoor.atlas.indoor.IndoorManager.setDynamicStyling
     package: azure-maps-indoor

--- a/docs-ref-autogen/azure-maps-indoor/atlas.indoor.IndoorManagerOptions.yml
+++ b/docs-ref-autogen/azure-maps-indoor/atlas.indoor.IndoorManagerOptions.yml
@@ -8,6 +8,34 @@ remarks: ''
 isDeprecated: false
 type: class
 properties:
+  - name: autofocus
+    uid: azure-maps-indoor.atlas.indoor.IndoorManagerOptions.autofocus
+    package: azure-maps-indoor
+    summary: >-
+      Automatically focus the camera on indoor facilities once the indoor is
+      loaded.
+    fullName: autofocus
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: 'autofocus?: boolean'
+      return:
+        description: ''
+        type: boolean
+  - name: autofocusOptions
+    uid: azure-maps-indoor.atlas.indoor.IndoorManagerOptions.autofocusOptions
+    package: azure-maps-indoor
+    summary: Options for the camera automatic focus.
+    fullName: autofocusOptions
+    remarks: ''
+    isDeprecated: false
+    syntax:
+      content: 'autofocusOptions?: azmaps.CameraBoundsOptions & azmaps.AnimationOptions'
+      return:
+        description: ''
+        type: >-
+          <xref uid="azmaps.CameraBoundsOptions" /> & <xref
+          uid="azmaps.AnimationOptions" />
   - name: geography
     uid: azure-maps-indoor.atlas.indoor.IndoorManagerOptions.geography
     package: azure-maps-indoor
@@ -38,17 +66,24 @@ properties:
   - name: statesetId
     uid: azure-maps-indoor.atlas.indoor.IndoorManagerOptions.statesetId
     package: azure-maps-indoor
-    summary: |-
-      The state set id to pass with requests.
+    summary: >-
+      The state set id or a state set id mapping used for dynamic styling.
+
+      When using map configuration with multiple indoor tilesets, pass a mapping
+      of tileset id to state set id.
+
+      When provided, calling setDynamicStyling(true) will enable dynamic
+      styling.
+
       default: `undefined`
     fullName: statesetId
     remarks: ''
     isDeprecated: false
     syntax:
-      content: 'statesetId?: string'
+      content: 'statesetId?: string | [key: string]: string'
       return:
         description: ''
-        type: string
+        type: 'string | [key: string]: string'
   - name: theme
     uid: azure-maps-indoor.atlas.indoor.IndoorManagerOptions.theme
     package: azure-maps-indoor


### PR DESCRIPTION
 Build.Reason:Manual by Taras Vozniuk
 Build.Url:https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=360528&view=results
 
 This generation has been made by locking the CI to run on https://www.npmjs.com/package/@microsoft/type2docfx/v/1.3.1 as after @latest update to v2, the namespace generation is no longer working properly with the entire doc structure essentially regenerated. 