### PR TITLE
Fix breadcrumbs

### DIFF
--- a/bread/toc.yml
+++ b/bread/toc.yml
@@ -1,5 +1,3 @@
-
-- name: Docs
-  tocHref: /
-  topicHref: /
-  items:
+- name: Azure
+  tocHref: /javascript/api/
+  topicHref: /azure/index

--- a/docfx.json
+++ b/docfx.json
@@ -60,7 +60,7 @@
     },
     "globalMetadata": {
       "uhfHeaderId": "Azure",
-      "breadcrumb_path": "/javascript/api/azure-iot-docs-sdk-typescript/bread/toc.json",
+      "breadcrumb_path": "/javascript/api/bread/toc.json",
       "toc_path": "/javascript/api/azure-iot-docs-sdk-typescript/toc.json",
       "products": [
         "https://authoring-docs-microsoft.poolparty.biz/devrel/68ec7f3a-2bc6-459f-b959-19beb729907d",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.